### PR TITLE
Be better Prometheus citizens

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,12 @@ metrics at `/metrics`. The following metrics exist:
 ```bash
 $ kubectl -n kube-system exec -it ${DRAINO_POD} -- apk add curl
 $ kubectl -n kube-system exec -it ${DRAINO_POD} -- curl http://localhost:10002/metrics
-# HELP draino_nodes_cordoned Number of nodes cordoned.
-# TYPE draino_nodes_cordoned counter
-draino_nodes_cordoned{node_name="coolnode",result="succeeded"} 1
-draino_nodes_cordoned{node_name="ambivalentnode",result="succeeded"} 1
-draino_nodes_cordoned{node_name="lamenode",result="failed"} 1
-# HELP draino_nodes_drained Number of nodes drained.
-# TYPE draino_nodes_drained counter
-draino_nodes_drained{node_name="coolnode",result="succeeded"} 1
-draino_nodes_drained{node_name="ambivalentnode",result="failed"} 1
+# HELP draino_cordoned_nodes_total Number of nodes cordoned.
+# TYPE draino_cordoned_nodes_total counter
+draino_cordoned_nodes_total{result="succeeded"} 2
+draino_cordoned_nodes_total{result="failed"} 1
+# HELP draino_drained_nodes_total Number of nodes drained.
+# TYPE draino_drained_nodes_total counter
+draino_drained_nodes_total{result="succeeded"} 1
+draino_drained_nodes_total{result="failed"} 1
 ```

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -49,18 +49,18 @@ func main() {
 
 	var (
 		nodesCordoned = &view.View{
-			Name:        "nodes_cordoned",
+			Name:        "cordoned_nodes_total",
 			Measure:     kubernetes.MeasureNodesCordoned,
 			Description: "Number of nodes cordoned.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagNodeName, kubernetes.TagResult},
+			TagKeys:     []tag.Key{kubernetes.TagResult},
 		}
 		nodesDrained = &view.View{
-			Name:        "nodes_drained",
+			Name:        "drained_nodes_total",
 			Measure:     kubernetes.MeasureNodesDrained,
 			Description: "Number of nodes drained.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagNodeName, kubernetes.TagResult},
+			TagKeys:     []tag.Key{kubernetes.TagResult},
 		}
 	)
 	kingpin.FatalIfError(view.Register(nodesCordoned, nodesDrained), "cannot create metrics")


### PR DESCRIPTION
This commit drops the node label, which can introduce high cardinality, and renames the labels to follow the thing_unit_total metric name that is considered a best practice per https://prometheus.io/docs/practices/naming/#metric-names